### PR TITLE
Revert "Do not specify `coq` as a dependency (#26)"

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -17,4 +17,10 @@
  (name coqfmt)
  (synopsis "Coq code formatter")
  (description "Coqfmt formats the given Coq source code in a uniform style.")
- (depends alcotest coq-core.plugins.ltac dune ocaml))
+ (depends
+  alcotest
+  coq ; FIXME: We should not specify Coq as a dependency as users may have
+      ; already installed it. However, removing it and installing Coq via
+      ; opam causes a build error on CI.
+  dune
+  ocaml))


### PR DESCRIPTION
This reverts commit d397aaee315edded586b968074b5413c286be894.

CI passed because I forgot to update the opam file. Updating it caused CI failures.

Closes #30 
Closes #31 