### PR TITLE
Use STM to memorize previous states

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -1,12 +1,24 @@
 type t = Vernacexpr.vernac_control list
 
 let generate_from_code code =
-  let mode = Ltac_plugin.G_ltac.classic_proof_mode in
-  let entry = Pvernac.main_entry (Some mode) in
-  let parser = Gramlib.Stream.of_string code |> Pcoq.Parsable.make in
-  let rec f acc =
-    match Pcoq.Entry.parse entry parser with
-    | None -> List.rev acc
-    | Some ast -> f (ast :: acc)
+  (* XXX: I don't know what is the correct value of `doc_type`. *)
+  let stm_init_options =
+    Stm.
+      {
+        doc_type = Interactive (TopLogical Names.DirPath.initial);
+        injections =
+          [ Coqargs.RequireInjection ("Prelude", Some "Coq", Some Import) ];
+      }
   in
-  f []
+
+  let init_doc, init_state = Stm.new_doc stm_init_options in
+
+  let parser = Gramlib.Stream.of_string code |> Pcoq.Parsable.make in
+  let rec f doc state acc =
+    match Stm.parse_sentence ~doc ~entry:Pvernac.main_entry state parser with
+    | None -> List.rev acc
+    | Some ast ->
+        let next_doc, next_state, _ = Stm.add ~doc ~ontop:state false ast in
+        f next_doc next_state (ast :: acc)
+  in
+  f init_doc init_state []

--- a/lib/init.ml
+++ b/lib/init.ml
@@ -1,11 +1,16 @@
 (* This function follows the instructions written in
-   https://coq.github.io/doc/master/api/coq-core/Coqinit/index.html. *)
+   https://coq.github.io/doc/master/api/coq-core/Coqinit/index.html except
+   `start_library` as it is called from `Stm.new_doc`. *)
 let init_coq () =
-  Coqinit.parse_arguments
-    ~parse_extra:(fun _ -> ((), []))
-    ~usage:
-      Boot.Usage.
-        { executable_name = "coqfmt"; extra_args = ""; extra_options = "" }
-    ()
-  |> fst |> Coqinit.init_runtime
-  |> Coqinit.start_library ~top:Names.DirPath.initial
+  let _ =
+    Coqinit.init_ocaml ();
+    Coqinit.parse_arguments
+      ~parse_extra:(fun _ -> ((), []))
+      ~usage:
+        Boot.Usage.
+          { executable_name = "coqfmt"; extra_args = ""; extra_options = "" }
+      ()
+    |> fst |> Coqinit.init_runtime
+  in
+  Stm.init_core ();
+  Stm.init_process Stm.AsyncOpts.default_opts


### PR DESCRIPTION
Unlike Haskell, Coq parser needs to memorize what is inputted, otherwise it can't parse notations defined earlier.
