### PR TITLE
Always append a `->` for a rewrite from left to right

### DIFF
--- a/lib/ppast.ml
+++ b/lib/ppast.ml
@@ -283,7 +283,7 @@ let pp_raw_atomic_tactic_expr printer (expr : Tacexpr.raw_atomic_tactic_expr) =
         [ (true, Precisely 1, (None, (expr, NoBindings))) ],
         Locus.{ onhyps = Some []; concl_occs = AllOccurrences },
         None ) ->
-      write printer "rewrite ";
+      write printer "rewrite -> ";
       pp_constr_expr printer expr;
       write printer "."
   | _ -> raise (NotImplemented (contents printer))

--- a/test/coq_files/tactics/rewrite/left-to-right-arrow/in.v
+++ b/test/coq_files/tactics/rewrite/left-to-right-arrow/in.v
@@ -1,0 +1,1 @@
+Theorem foo:forall (n m:nat),n=m->n=m. Proof. intros n m H. rewrite -> H. reflexivity. Qed.

--- a/test/coq_files/tactics/rewrite/left-to-right-arrow/out.v
+++ b/test/coq_files/tactics/rewrite/left-to-right-arrow/out.v
@@ -1,0 +1,6 @@
+Theorem foo : forall (n m : nat), n = m -> n = m.
+Proof.
+  intros n m H.
+  rewrite -> H.
+  reflexivity.
+Qed.

--- a/test/coq_files/tactics/rewrite/no-direction/out.v
+++ b/test/coq_files/tactics/rewrite/no-direction/out.v
@@ -1,6 +1,6 @@
 Theorem foo : forall (n m : nat), n = m -> n = m.
 Proof.
   intros n m H.
-  rewrite H.
+  rewrite -> H.
   reflexivity.
 Qed.


### PR DESCRIPTION
For readability, though I'm not sure which (with or without `->`) is better.