### PR TITLE
Add option wrap-comments to .ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
 version = 0.25.1
+wrap-comments


### PR DESCRIPTION
This option wraps comments so they do not exceed 80 columns.