### PR TITLE
s/(commad|spaced|bard)/map_\1/g

### DIFF
--- a/lib/ppast.ml
+++ b/lib/ppast.ml
@@ -179,14 +179,14 @@ and pp_constr_expr_r = function
       hor <-|> ver
   | Constrexpr.CPrim prim -> pp_prim_token prim
   | Constrexpr.CProdN (xs, CAst.{ v = Constrexpr.CHole _; loc = _ }) ->
-      spaced pp_local_binder_expr xs
+      map_spaced pp_local_binder_expr xs
   | Constrexpr.CProdN (xs, ty) ->
       let hor = sequence [ space; pp_constr_expr ty ] in
       let ver = sequence [ newline; indented (pp_constr_expr ty) ] in
       sequence
         [
           write "forall ";
-          spaced pp_local_binder_expr xs;
+          map_spaced pp_local_binder_expr xs;
           write ",";
           hor <-|> ver;
         ]
@@ -206,7 +206,7 @@ and pp_local_binder_expr = function
       pp_lname name
   | Constrexpr.CLocalAssum (names, Constrexpr.Default Explicit, ty) ->
       parens
-        (sequence [ spaced pp_lname names; write " : "; pp_constr_expr ty ])
+        (sequence [ map_spaced pp_lname names; write " : "; pp_constr_expr ty ])
   | _ -> fun printer -> raise (NotImplemented (contents printer))
 
 and pp_branch_expr = function
@@ -286,7 +286,7 @@ let pp_fixpoint_expr = function
         [
           pp_lident fname;
           space;
-          spaced pp_local_binder_expr binders;
+          map_spaced pp_local_binder_expr binders;
           pp_return_type;
           write " :=";
           newline;
@@ -349,10 +349,10 @@ let rec pp_or_and_intro_pattern_expr = function
       let pp_patterns i pattern =
         match (i, pattern) with
         | 0, [] -> space
-        | 0, xs -> spaced (fun x -> pp_intro_pattern_expr x.v) xs
+        | 0, xs -> map_spaced (fun x -> pp_intro_pattern_expr x.v) xs
         | _, xs ->
             sequence
-              [ write "| "; spaced (fun x -> pp_intro_pattern_expr x.v) xs ]
+              [ write "| "; map_spaced (fun x -> pp_intro_pattern_expr x.v) xs ]
       in
       brackets (sequence (List.mapi pp_patterns patterns))
   | _ -> fun printer -> raise (NotImplemented (contents printer))
@@ -420,7 +420,7 @@ let pp_raw_atomic_tactic_expr = function
       sequence
         [
           write "intros ";
-          spaced (fun expr -> pp_intro_pattern_expr expr.v) exprs;
+          map_spaced (fun expr -> pp_intro_pattern_expr expr.v) exprs;
           write ".";
         ]
   | Tacexpr.TacReduce (expr, _) -> pp_raw_red_expr expr
@@ -464,7 +464,7 @@ let pp_gen_tactic_expr_r = function
 
       (* The last element is Coq's internal ID and we don't need it. *)
       let init_idents = String.split_on_char '_' id |> init in
-      let spaced' fs =
+      let map_spaced' fs =
         List.mapi
           (fun i f -> match i with 0 -> f | _ -> sequence [ space; f ])
           fs
@@ -482,7 +482,7 @@ let pp_gen_tactic_expr_r = function
         | [], _ -> failwith "Too many replacers."
         | h_id :: t_id, _ -> write h_id :: loop t_id replacers
       in
-      sequence [ loop init_idents init_replacers |> spaced'; write "." ]
+      sequence [ loop init_idents init_replacers |> map_spaced'; write "." ]
   | Tacexpr.TacArg arg -> pp_gen_tactic_arg arg
   | Tacexpr.TacAtom atom -> pp_raw_atomic_tactic_expr atom
   | _ -> fun printer -> raise (NotImplemented (contents printer))

--- a/lib/ppast.ml
+++ b/lib/ppast.ml
@@ -113,7 +113,7 @@ and pp_constr_expr_r = function
       sequence
         [
           write "match ";
-          commad pp_case_expr matchees;
+          map_commad pp_case_expr matchees;
           write " with";
           newline;
           map_sequence
@@ -216,7 +216,7 @@ and pp_branch_expr = function
       sequence
         [
           write "| ";
-          bard (commad pp_cases_pattern_expr) patterns;
+          bard (map_commad pp_cases_pattern_expr) patterns;
           write " =>";
           hor <-|> ver;
         ]
@@ -533,7 +533,7 @@ let pp_import_categories { Vernacexpr.negative; import_cats } =
     [
       space;
       (if negative then write "-" else nop);
-      parens (commad (fun import_cat -> write import_cat.v) import_cats);
+      parens (map_commad (fun import_cat -> write import_cat.v) import_cats);
     ]
 
 let pp_export_flag = function
@@ -558,7 +558,8 @@ let pp_import_filter_expr import_filter_expr =
         [
           (* FIXME: The Coq parser will raise an exception here if Export/Import
              was omitted *)
-          parens (commad (fun (filter_name, _) -> pp_qualid filter_name) names);
+          parens
+            (map_commad (fun (filter_name, _) -> pp_qualid filter_name) names);
         ]
 
 let pp_subast CAst.{ v = Vernacexpr.{ control = _; attrs = _; expr }; loc = _ }
@@ -599,7 +600,7 @@ let pp_subast CAst.{ v = Vernacexpr.{ control = _; attrs = _; expr }; loc = _ }
           [
             space;
             parens
-              (commad
+              (map_commad
                  (fun modifier ->
                    let open CAst in
                    pp_syntax_modifier modifier.v)

--- a/lib/ppast.ml
+++ b/lib/ppast.ml
@@ -70,7 +70,7 @@ and pp_cases_pattern_expr_r = function
           write suffix;
         ]
   | Constrexpr.CPatPrim token -> pp_prim_token token
-  | Constrexpr.CPatOr xs -> parens (bard pp_cases_pattern_expr xs)
+  | Constrexpr.CPatOr xs -> parens (map_bard pp_cases_pattern_expr xs)
   | _ -> fun printer -> raise (NotImplemented (contents printer))
 
 let pp_sort_name_expr = function
@@ -216,7 +216,7 @@ and pp_branch_expr = function
       sequence
         [
           write "| ";
-          bard (map_commad pp_cases_pattern_expr) patterns;
+          map_bard (map_commad pp_cases_pattern_expr) patterns;
           write " =>";
           hor <-|> ver;
         ]

--- a/lib/printer.ml
+++ b/lib/printer.ml
@@ -90,7 +90,7 @@ let with_seps ~sep f xs =
        xs)
 
 let map_commad f = with_seps ~sep:(write ", ") f
-let spaced f = with_seps ~sep:space f
+let map_spaced f = with_seps ~sep:space f
 let bard f = with_seps ~sep:(write " | ") f
 
 let copy_printer_by_value t =

--- a/lib/printer.ml
+++ b/lib/printer.ml
@@ -89,7 +89,7 @@ let with_seps ~sep f xs =
        (fun i x -> match i with 0 -> f x | _ -> sequence [ sep; f x ])
        xs)
 
-let commad f = with_seps ~sep:(write ", ") f
+let map_commad f = with_seps ~sep:(write ", ") f
 let spaced f = with_seps ~sep:space f
 let bard f = with_seps ~sep:(write " | ") f
 

--- a/lib/printer.ml
+++ b/lib/printer.ml
@@ -91,7 +91,7 @@ let with_seps ~sep f xs =
 
 let map_commad f = with_seps ~sep:(write ", ") f
 let map_spaced f = with_seps ~sep:space f
-let bard f = with_seps ~sep:(write " | ") f
+let map_bard f = with_seps ~sep:(write " | ") f
 
 let copy_printer_by_value t =
   let buffer = Buffer.create 16 in

--- a/lib/printer.mli
+++ b/lib/printer.mli
@@ -52,7 +52,7 @@ val with_seps : sep:(t -> unit) -> ('a -> t -> unit) -> 'a list -> t -> unit
 val map_commad : ('a -> t -> unit) -> 'a list -> t -> unit
 (** Write out a comma-separated list of elements. *)
 
-val spaced : ('a -> t -> unit) -> 'a list -> t -> unit
+val map_spaced : ('a -> t -> unit) -> 'a list -> t -> unit
 (** Write out a space-separated list of elements. *)
 
 val bard : ('a -> t -> unit) -> 'a list -> t -> unit

--- a/lib/printer.mli
+++ b/lib/printer.mli
@@ -49,7 +49,7 @@ val brackets : (t -> unit) -> t -> unit
 val with_seps : sep:(t -> unit) -> ('a -> t -> unit) -> 'a list -> t -> unit
 (** Arrange a series of elements with [~sep] as the delimiter  *)
 
-val commad : ('a -> t -> unit) -> 'a list -> t -> unit
+val map_commad : ('a -> t -> unit) -> 'a list -> t -> unit
 (** Write out a comma-separated list of elements. *)
 
 val spaced : ('a -> t -> unit) -> 'a list -> t -> unit

--- a/lib/printer.mli
+++ b/lib/printer.mli
@@ -50,13 +50,16 @@ val with_seps : sep:(t -> unit) -> ('a -> t -> unit) -> 'a list -> t -> unit
 (** Arrange a series of elements with [~sep] as the delimiter  *)
 
 val map_commad : ('a -> t -> unit) -> 'a list -> t -> unit
-(** Write out a comma-separated list of elements. *)
+(** Map the elements of the given list to printers and run them
+  comma-separatedly. *)
 
 val map_spaced : ('a -> t -> unit) -> 'a list -> t -> unit
-(** Write out a space-separated list of elements. *)
+(** Map the elements of the given list to printers and run them
+  space-separatedly. *)
 
 val map_bard : ('a -> t -> unit) -> 'a list -> t -> unit
-(** Write out a bar-separated list of elements. *)
+(** Map the elements of the given list to printers and run them
+  bar-separatedly. *)
 
 val ( <-|> ) : (t -> unit) -> (t -> unit) -> t -> unit
 (** Try running the first printer. If the result fits in the columns limit, use

--- a/lib/printer.mli
+++ b/lib/printer.mli
@@ -55,7 +55,7 @@ val map_commad : ('a -> t -> unit) -> 'a list -> t -> unit
 val map_spaced : ('a -> t -> unit) -> 'a list -> t -> unit
 (** Write out a space-separated list of elements. *)
 
-val bard : ('a -> t -> unit) -> 'a list -> t -> unit
+val map_bard : ('a -> t -> unit) -> 'a list -> t -> unit
 (** Write out a bar-separated list of elements. *)
 
 val ( <-|> ) : (t -> unit) -> (t -> unit) -> t -> unit


### PR DESCRIPTION
To define `spaced` which runs printers space-separatedly.
