### PR TITLE
Do not enforce all outputs to be within 80 cols

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,20 +106,6 @@ jobs:
           shopt -s globstar
           find ./test/coq_files/**/*.v -print0|xargs -0 -I{} sh -c 'echo -n "{}: "; opam exec -- coqc -q -vio {} > /dev/null && echo "OK" || exit 255'
 
-  eighty_columns_check:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4.1.0
-
-      - name: Try
-        run: find ./test/coq_files/**/out.v -exec wc -L {} \;
-
-      - name: List formatted Coq files that have a line longer than 80 characters
-        run: |
-          shopt -s globstar
-          find ./test/coq_files/**/out.v -exec wc -L {} \;|awk '$1 > 80 {print $2;error=1} END {exit error}'
-
   docker:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Two reasons:
- I'm a lazy person.
- `coqfmt` can't wrap all outputs within 80 columns (e.g., a `Theorem` with a very long name.)
