### PR TITLE
Pin versions of external GitHub Actions by hashes

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -19,9 +19,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - uses: ocaml/setup-ocaml@v2.2.8
+      - uses: ocaml/setup-ocaml@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
         with:
           ocaml-compiler: "4.14.1"
           dune-cache: true
@@ -33,13 +33,13 @@ jobs:
         run: opam exec -- dune build @doc
 
       - name: Set-up Pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: _build/default/_doc/_html
 
       - name: Deploy odoc to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
 
   pull_request:
 
-
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 
   pull_request:
 
+
 jobs:
   test:
     strategy:
@@ -26,10 +27,10 @@ jobs:
       - name: Modify the git setting not to convert LF to CRLF
         run: git config --global core.autocrlf input
 
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       # See https://github.com/ocaml-opam/opam-repository-mingw#updates for `opam-repositories`.
-      - uses: ocaml/setup-ocaml@v2.2.8
+      - uses: ocaml/setup-ocaml@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
         with:
           ocaml-compiler: "4.14.1"
           opam-repositories: |
@@ -56,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: Run Prettier
         run: npx --yes prettier --check .
@@ -65,35 +66,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - uses: ocaml/setup-ocaml@v2.2.8
+      - uses: ocaml/setup-ocaml@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
         with:
           ocaml-compiler: "4.14.1"
           dune-cache: true
 
-      - uses: ocaml/setup-ocaml/lint-fmt@v2.2.8
+      - uses: ocaml/setup-ocaml/lint-fmt@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
 
   lint_docs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - uses: ocaml/setup-ocaml@v2.2.8
+      - uses: ocaml/setup-ocaml@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
         with:
           ocaml-compiler: "4.14.1"
           dune-cache: true
 
-      - uses: ocaml/setup-ocaml/lint-doc@v2.2.8
+      - uses: ocaml/setup-ocaml/lint-doc@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
 
   test_coq_files:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - uses: ocaml/setup-ocaml@v2.2.8
+      - uses: ocaml/setup-ocaml@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
         with:
           ocaml-compiler: "4.14.1"
           dune-cache: true
@@ -110,20 +111,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - uses: ocaml/setup-ocaml@v2.2.8
+      - uses: ocaml/setup-ocaml@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
         with:
           ocaml-compiler: "4.14.1"
           dune-cache: true
 
-      - uses: ocaml/setup-ocaml/lint-opam@v2.2.8
+      - uses: ocaml/setup-ocaml/lint-opam@42bf33a4dd3ba5d75a4c9ea6b27d960c9eb4a018 # v2.2.8
 
   docker:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: Build Docker image
         run: docker build -t coqfmt .
@@ -135,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: List all non-empty files tracked by git that do not end with a newline
         run: git ls-files | xargs -I {} sh -c '[ -s "{}" ] && echo "{}"' | xargs -I {} sh -c 'tail -c 1 {} | read -r _ || (echo "{}"; false)'
@@ -144,14 +145,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
 
   markdown-lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - uses: DavidAnson/markdownlint-cli2-action@v16.0.0
+      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16.0.0


### PR DESCRIPTION
See
https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash.
