### PR TITLE
PP Arguments modifiers

### DIFF
--- a/lib/ppast.ml
+++ b/lib/ppast.ml
@@ -1630,6 +1630,18 @@ let pp_vernac_argument_status = function
       encloser (pp_name ty)
   | _ -> fun printer -> raise (Not_implemented (contents printer))
 
+let pp_vernac_arguments_modifier = function
+  | `Assert -> write "assert"
+  | `ClearBidiHint -> write "clear bidirectionality hint"
+  | `ClearImplicits -> write "clear implicits"
+  | `ClearScopes -> write "clear scopes"
+  | `DefaultImplicits -> write "default implicits"
+  | `ExtraScopes -> write "extra scopes"
+  | `ReductionDontExposeCase -> write "simpl nomatch"
+  | `ReductionNeverUnfold -> write "simpl never"
+  | `Rename -> write "rename"
+  | _ -> fun printer -> raise (Not_implemented (contents printer))
+
 let pp_option_string = function
   | Vernacexpr.OptionSetString s -> doublequoted (write s)
   | _ -> fun printer -> raise (Not_implemented (contents printer))
@@ -2095,15 +2107,19 @@ let pp_synpure_vernac_expr = function
           map_spaced pp_table_value names;
           dot;
         ]
-  | Vernacexpr.VernacArguments (CAst.{ v = AN name; loc = _ }, args, [], []) ->
-      sequence
-        [
-          write "Arguments ";
-          pp_qualid name;
-          space;
-          map_spaced pp_vernac_argument_status args;
-          dot;
-        ]
+  | Vernacexpr.VernacArguments (CAst.{ v = AN name; loc = _ }, args, [], mods)
+    ->
+      let pp_args =
+        if args <> [] then
+          sequence [ space; map_spaced pp_vernac_argument_status args ]
+        else fun _ -> ()
+      in
+      let pp_mods =
+        if mods <> [] then
+          sequence [ write " : "; map_commad pp_vernac_arguments_modifier mods ]
+        else fun _ -> ()
+      in
+      sequence [ write "Arguments "; pp_qualid name; pp_args; pp_mods; dot ]
   | Vernacexpr.VernacAssumption
       ((NoDischarge, kind), NoInline, [ (NoCoercion, ([ name ], expr)) ]) ->
       sequence

--- a/test/coq_files/command/arguments/modifiers/in.v
+++ b/test/coq_files/command/arguments/modifiers/in.v
@@ -1,0 +1,1 @@
+Definition x := 1. Arguments x   : assert,simpl   never .

--- a/test/coq_files/command/arguments/modifiers/out.v
+++ b/test/coq_files/command/arguments/modifiers/out.v
@@ -1,0 +1,3 @@
+Definition x := 1.
+
+Arguments x : assert, simpl never.


### PR DESCRIPTION
Adds support for `Arguments` [modifiers](https://coq.inria.fr/doc/v8.19/refman/language/extensions/arguments-command.html?highlight=arguments#grammar-token-args_modifier). It might be worth writing something like a `pp_if` combinator to make the `if ... then ... else fun _ -> ()` pattern cleaner.