### PR TITLE
PP Generalizable

### DIFF
--- a/lib/ppast.ml
+++ b/lib/ppast.ml
@@ -2230,6 +2230,20 @@ let pp_synpure_vernac_expr = function
             pp_fixpoint_expr exprs;
           dot;
         ]
+  | Vernacexpr.VernacGeneralizable None -> write "Generalizable No Variables."
+  | Vernacexpr.VernacGeneralizable (Some names) ->
+      let variable_kwd =
+        match names with
+        | [] -> "All Variables"
+        | [ _ ] -> "Variable "
+        | _ -> "Variables "
+      in
+      sequence
+        [
+          write ("Generalizable " ^ variable_kwd);
+          map_spaced pp_lident names;
+          dot;
+        ]
   | Vernacexpr.VernacLocate (LocateAny CAst.{ v = Constrexpr.AN name; loc = _ })
     ->
       sequence [ write "Locate "; pp_qualid name; dot ]

--- a/test/coq_files/command/generalizable/in.v
+++ b/test/coq_files/command/generalizable/in.v
@@ -1,0 +1,1 @@
+Generalizable   Variable  a.    Generalizable Variable b c . Generalizable Variables d  e. Generalizable  All    Variables  .  Generalizable   No   Variables.

--- a/test/coq_files/command/generalizable/out.v
+++ b/test/coq_files/command/generalizable/out.v
@@ -1,0 +1,5 @@
+Generalizable Variable a.
+Generalizable Variables b c.
+Generalizable Variables d e.
+Generalizable All Variables.
+Generalizable No Variables.


### PR DESCRIPTION
Adds support for [`Generalizable`](https://coq.inria.fr/doc/v8.19/refman/language/extensions/implicit-arguments.html?highlight=generalizable#coq:cmd.Generalizable). Do you have any thoughts about whether `coqfmt` should try to use the appropriate singular or plural form of commands or whether it should just normalize everything to one or the other?