### PR TITLE
PP record projections

### DIFF
--- a/test/coq_files/expression/projection/in.v
+++ b/test/coq_files/expression/projection/in.v
@@ -1,0 +1,1 @@
+Record R X {Y} := { rx: X; ry: Y }. Definition x1 (r: @R unit unit) := r.( rx  unit  ) . Definition x2 r := r .( @ rx). Definition x3 r := r.(@rx unit unit) . Definition x4 r := r.(rx  unit   (  Y:=unit) ).

--- a/test/coq_files/expression/projection/out.v
+++ b/test/coq_files/expression/projection/out.v
@@ -1,0 +1,12 @@
+Record R X {Y : _} := {
+  rx : X;
+  ry : Y;
+}.
+
+Definition x1 (r : @R unit unit) := r.(rx unit).
+
+Definition x2 r := r.(@rx).
+
+Definition x3 r := r.(@rx unit unit).
+
+Definition x4 r := r.(rx unit (Y := unit)).


### PR DESCRIPTION
Adds support for [record projection expressions](https://coq.inria.fr/doc/v8.19/refman/language/core/records.html?highlight=projection#grammar-token-term_projection) and [named arguments](https://coq.inria.fr/doc/v8.19/refman/language/core/assumptions.html#grammar-token-arg) (`f (x := y)` or `f (1 := y)`). Currently only supports projections without universe annotations. 