### PR TITLE
ci: disable CI on Windows temporarily

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          # Running on Windows is temporarily disabled because `dune test` hangs.
+          # - windows-latest
+          #
           # Running on macOS is temporarily disabled due to a build failure of
           # `coq-core`.
           # - macos-latest


### PR DESCRIPTION
Due to the hang on `dune test`.
